### PR TITLE
Make the plugin less likely to override other plugins cache settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix fatal error caused by passing a string where int expected
 - Fix a bug in the taxonomy processing 
 - Fix bug in template config logic
+
+## [0.1.2] - 2022-11-xx
+### Added
+- Checks that the wp_headers filter hasn't modified to cache-control header to no-cache
+
+### Changed
+- Sets the setCacheHeader method to run first in the send_headers action to give other plugins the opportunity to override the cache setting

--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/dxw/dxw-cache-control
  * Description: Set the Cache control headers by content type, taxonomy, template etc.
  * Author: dxw
- * Version: 0.1.1
+ * Version: 0.1.2
  * Network: True
  */
 


### PR DESCRIPTION
This commit changes to plugin so that it checks the header array set in the wp_headers filter, and if there is no logged in user and the cache-control header has been set to no-cache then the setCacheHeader method exits before it outputs any relvant headers.

Additionally, the setCacheHeader is now executed as the priority 1 task in the send_headers action loop, which will give any other plugins which use the send_headers action, or any later action the opportunity to override the cache-control header set by the plugin.

This should ensure that this plugin isn't overriding any other plugins that are setting cache-control headers, providing that they are using the wp_headers filter, the send_headers action, or an action that executes after the send_headers action has been executed.

If a plugin is setting the cache-control header before the send_headers action is executed then there is little we can do here, other than raise a bug with the developer of that plugin.