### PR TITLE
Resolve issue where fatal errors can be caused by individual page cac…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2024-01-19
+### Fixed
+- Individual post cache config no longer throws a fatal error where the cache value is set as 'default'.
+- Where there is an empty row in the individual page cache settings this config will no longer be processed.
+
 ## [0.2.0] - 2023-09-15
 ### Added
 - Individual posts (including pages and custom post types) can now be targeted and assigned their own cache values.

--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/dxw/dxw-cache-control
  * Description: Set the Cache control headers by content type, taxonomy, template etc.
  * Author: dxw
- * Version: 0.2.0
+ * Version: 0.2.1
  * Requires at least: 6.1
  * Network: True
  */

--- a/spec/send_headers.spec.php
+++ b/spec/send_headers.spec.php
@@ -705,6 +705,34 @@ describe(\CacheControl\SendHeaders::class, function () {
 				$this->sendHeaders->setCacheHeader();
 			});
 
+			it('current page has post ID, and a cache override is configured as "default"', function () {
+				$this->config['field_cache_control_individual_post_settings'] = [
+					[
+						'cache_control_individual_post_post_id' => 2,
+						'cache_control_individual_post_cache_age' => 'default'
+					]
+				];
+				allow('get_post')->toBeCalled()->andReturn($this->postObj);
+				allow('header')->toBeCalled();
+				expect('header')->toBeCalled()->once()->with('Cache-Control: max-age=86400, public');
+
+				$this->sendHeaders->setCacheHeader();
+			});
+
+			it('current page has post ID, and a cache override is configured for id " "', function () {
+				$this->config['field_cache_control_individual_post_settings'] = [
+					[
+						'cache_control_individual_post_post_id' => '',
+						'cache_control_individual_post_cache_age' => 120
+					]
+				];
+				allow('get_post')->toBeCalled()->andReturn($this->postObj);
+				allow('header')->toBeCalled();
+				expect('header')->toBeCalled()->once()->with('Cache-Control: max-age=86400, public');
+
+				$this->sendHeaders->setCacheHeader();
+			});
+
 			it('current page has post ID, but not one configured with a cache override', function () {
 				$this->postObj->ID = 3;
 

--- a/src/SendHeaders.php
+++ b/src/SendHeaders.php
@@ -172,8 +172,11 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 		if (have_rows('field_cache_control_individual_post_settings', 'options')) {
 			$rows = get_field('field_cache_control_individual_post_settings', 'options');
 			foreach ($rows as $row) {
-				if ($this->pageProperties['postId'] == $row['cache_control_individual_post_post_id']) {
-					$this->maxAge = $row['cache_control_individual_post_cache_age'];
+				if (!empty($row['cache_control_individual_post_post_id']) && $this->pageProperties['postId'] == $row['cache_control_individual_post_post_id']) {
+					if ($row['cache_control_individual_post_cache_age'] != 'default') {
+						$this->maxAge = $row['cache_control_individual_post_cache_age'];
+					}
+
 					if ($this->developerMode) {
 						header('Meta-cc-config-individual-post-max-age: ' . $this->maxAge);
 						header('Meta-cc-individual-page-cache-setting-triggered: Yes');


### PR DESCRIPTION
…he configured as 'default'

This commit resolves a couple of issues with the individual page cache functionality

- Where the cache value for a configured page ID is set as 'default' this will no longer cause a fatal error due to a type mismatch.
- Where there is a row in the individual page cache settings array with an unset page ID this config will no longer be processed.

To test:
- install this plugin on a test site, and configure a known page ID with the cache setting 'default'
- confirm that the instance no longer throws fatal errors where a string is attempting to be set in an int field
- configure the individual page config so there is a row in the config with no configured ID but with a cache value of 'default'
- confirm that no type mismatch fatal errors are shown in the logs while navigating the test site.