### PR TITLE
Add 5 minutes as an option for max-age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2024-05-08
+### Changed
+- Add an option to set a 5 minute max-age
+
 ## [0.2.1] - 2024-01-19
 ### Fixed
 - Individual post cache config no longer throws a fatal error where the cache value is set as 'default'.

--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/dxw/dxw-cache-control
  * Description: Set the Cache control headers by content type, taxonomy, template etc.
  * Author: dxw
- * Version: 0.2.1
+ * Version: 0.2.2
  * Requires at least: 6.1
  * Network: True
  */

--- a/src/Options.php
+++ b/src/Options.php
@@ -34,6 +34,7 @@ class Options implements \Dxw\Iguana\Registerable
 		$ageOptions = [
 			'default'   => 'Default',
 			120 		=> '2 mins',
+			300 		=> '5 mins',
 			900 		=> '15 mins',
 			1800 		=> '30 mins',
 			3600		=> '1 hr',


### PR DESCRIPTION
To test: start a local env running with the plugin checked out on this branch and check that the option appears in the dashboard.