### PR TITLE
Fix/preview pages headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Lowercased company name in plugin metadata
-- Bug where preview pages had public cache headers set
+- Bug where preview pages had public cache headers set and potentially other pages in developer mode
+
+### Changed
+- Developer mode is only available in 'local' and 'development' environment types
 
 ## [v1.0.0] - 2024-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Lowercased company name in plugin metadata
+
 ## [v1.0.0] - 2024-12-10
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix namespacing in composer.json
 - Fix fatal error caused by passing a string where int expected
-- Fix a bug in the taxonomy processing 
+- Fix a bug in the taxonomy processing
 - Fix bug in template config logic
 
 ## [0.1.0] - 2022-10-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Lowercased company name in plugin metadata
+- Bug where preview pages had public cache headers set
 
 ## [v1.0.0] - 2024-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Settings link appears in plugins page
+
 ### Fixed
 - Lowercased company name in plugin metadata
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This plugin adds the ability to set the cache-control header for any wordpress page displayed in the frontend to a 
 custom max-age value which is administrator controlled in the backend.
 
-The plugin only modifies the headers on the frontend of the site, and does not opperate at all in the administration 
+The plugin only modifies the headers on the frontend of the site, and does not operate at all in the administration
 pages of a wordpress site.
 
 NOTE: Version 1.0.0 onwards only supports PHP 8.2 and up.
@@ -41,7 +41,7 @@ This config section is only displayed if there are custom templates available, o
 Where this section is available each template config will state which post type this will affect.
 
 - $template_name cache: sets the max-age value for the template.
-- Overrides taxonomy cache age: sets wthere this template setting can override a configured taxonomy cache config, only applies to posts, taxonomy cache setting is always preferred on archive pages.
+- Overrides taxonomy cache age: sets where this template setting can override a configured taxonomy cache config, only applies to posts, taxonomy cache setting is always preferred on archive pages.
 
 ## Priority of configuration directives
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The default cache max-age is set to 24 hours, other than the front page config, 
 The front page config is always respected, regardless of other configuration, even if it is set to the default value.
 
 ### Global options
-- Developer mode flag: Disables the Logged In User override (not available production), outputs various headers with the prefix 'Meta-cc' that provide information on page properties and config state.
+- Developer mode flag: Disables the Logged In User override (only available in `local` or `development` WordPress environments), outputs various headers with the prefix 'Meta-cc' that provide information on page properties and config state.
 - Front Page Cache: Sets the max-age for the configured front page of the site.
 - Home Page Cache: Sets the max-age for the configured home page of the site (see [Wordpress function reference: is_home()](https://developer.wordpress.org/reference/functions/is_home/)) for details.
 - Archive Cache: Sets the max-age value for archive pages.

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
  * @license     MIT
  *
  * @wordpress-plugin
- * Plugin Name: DXW Cache Control
+ * Plugin Name: dxw Cache Control
  * Plugin URI: https://github.com/dxw/dxw-cache-control
  * Description: Set the Cache control headers by content type, taxonomy, template etc.
  * Author: dxw

--- a/spec/options.spec.php
+++ b/spec/options.spec.php
@@ -10,6 +10,30 @@ describe(\CacheControl\Options::class, function () {
 		expect($this->options)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
 	});
 
+	describe('->register()', function () {
+		it('adds actions and filters', function () {
+			allow('add_action')->toBeCalled();
+			expect('add_action')->toBeCalled()->times(2);
+			expect('add_action')->toBeCalled()->with('acf/init', [$this->options, 'addOptionsPage']);
+			expect('add_action')->toBeCalled()->with('init', [$this->options, 'addOptions'], 999);
+			allow('add_filter')->toBeCalled();
+			expect('add_filter')->toBeCalled()->with('plugin_action_links_dxw-cache-control/index.php', [$this->options, 'addActionLinks']);
+
+			$this->options->register();
+		});
+	});
+
+	describe('->addActionLinks()', function () {
+		it('adds a link to the settings page', function () {
+			allow('admin_url')->toBeCalled()->with('options-general.php?page=cache-control-settings')->andReturn('https://example.com/wp-admin/options-general.php?page=cache-control-settings');
+
+			$expected = ['<a href="https://example.com/wp-admin/options-general.php?page=cache-control-settings">Settings</a>'];
+			$result = $this->options->addActionLinks([]);
+
+			expect($result)->toEqual($expected);
+		});
+	});
+
 	describe('->addOptionsPage()', function () {
 		context('ACF is not activated', function () {
 			it('does nothing', function () {

--- a/spec/send_headers.spec.php
+++ b/spec/send_headers.spec.php
@@ -233,6 +233,17 @@ describe(\CacheControl\SendHeaders::class, function () {
 				$this->sendHeaders->setCacheHeader();
 			});
 
+			it('is on the local environment', function () {
+				allow('wp_get_environment_type')->toBeCalled()->andReturn('local');
+				expect('get_post_types')->toBeCalled()->once();
+				expect('get_field')->toBeCalled()->times(3);
+
+				allow('header')->toBeCalled();
+				expect('header')->toBeCalled()->times(17);
+
+				$this->sendHeaders->setCacheHeader();
+			});
+
 			it('is on the development environment', function () {
 				allow('wp_get_environment_type')->toBeCalled()->andReturn('development');
 				expect('get_post_types')->toBeCalled()->once();
@@ -246,11 +257,9 @@ describe(\CacheControl\SendHeaders::class, function () {
 
 			it('is on the staging environment', function () {
 				allow('wp_get_environment_type')->toBeCalled()->andReturn('staging');
-				expect('get_post_types')->toBeCalled()->once();
-				expect('get_field')->toBeCalled()->times(3);
 
 				allow('header')->toBeCalled();
-				expect('header')->toBeCalled()->times(17);
+				expect('header')->toBeCalled()->once()->with('Cache-Control: no-cache, no-store, private');
 
 				$this->sendHeaders->setCacheHeader();
 			});

--- a/spec/send_headers.spec.php
+++ b/spec/send_headers.spec.php
@@ -11,6 +11,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 		allow('is_front_page')->toBeCalled()->andReturn(false);
 		allow('is_home')->toBeCalled()->andReturn(false);
 		allow('is_user_logged_in')->toBeCalled()->andReturn(false);
+		allow('is_preview')->toBeCalled()->andReturn(false);
 		allow('get_post_type')->toBeCalled()->andReturn('post');
 		allow('get_post_taxonomies')->toBeCalled()->andReturn(['category', 'post_tag', 'custom-taxonomy']);
 		allow('get_page_template_slug')->toBeCalled()->andReturn('default');
@@ -148,6 +149,16 @@ describe(\CacheControl\SendHeaders::class, function () {
 				allow('is_user_logged_in')->toBeCalled()->andReturn(true);
 			});
 
+			it('sets a private cache header for preview pages', function () {
+				allow('is_preview')->toBeCalled()->andReturn(true);
+				expect('get_field')->toBeCalled()->once();
+
+				allow('header')->toBeCalled();
+				expect('header')->toBeCalled()->once()->with('Cache-Control: no-cache, no-store, private');
+
+				$this->sendHeaders->setCacheHeader();
+			});
+
 			it('is not in developer mode', function () {
 				expect('get_field')->toBeCalled()->once();
 
@@ -174,6 +185,18 @@ describe(\CacheControl\SendHeaders::class, function () {
 				expect('header')->toBeCalled()->once()->with('Cache-Control: no-cache, no-store, private');
 
 				$this->sendHeaders->getContext($this->headers['cache']);
+				$this->sendHeaders->setCacheHeader();
+			});
+		});
+
+		context('the user is not logged in', function () {
+			it('sets a private cache header for preview pages', function () {
+				allow('is_preview')->toBeCalled()->andReturn(true);
+				expect('get_field')->toBeCalled()->once();
+
+				allow('header')->toBeCalled();
+				expect('header')->toBeCalled()->once()->with('Cache-Control: no-cache, no-store, private');
+
 				$this->sendHeaders->setCacheHeader();
 			});
 		});

--- a/spec/send_headers.spec.php
+++ b/spec/send_headers.spec.php
@@ -210,7 +210,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 
 			it('is in developer mode on the local dev environment', function () {
 				expect('get_post_types')->toBeCalled()->once();
-				expect('get_field')->toBeCalled()->times(3);
+				expect('get_field')->toBeCalled()->times(1);
 
 				allow('header')->toBeCalled();
 				expect('header')->toBeCalled()->once()->with('Meta-cc-post-type: post');
@@ -223,12 +223,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 				expect('header')->toBeCalled()->once()->with('Meta-cc-template_name: default');
 				expect('header')->toBeCalled()->once()->with('Meta-cc-requires-password: no');
 				expect('header')->toBeCalled()->once()->with('Meta-cc-post-types: post,page,custom-post');
-				expect('header')->toBeCalled()->once()->with('Meta-cc-front-page-cache-value: default');
-				expect('header')->toBeCalled()->once()->with('Meta-cc-configured-max-age: 86400');
-				expect('header')->toBeCalled()->once()->with('Meta-cc-configured-cache: no-cache (logged in user)');
-				expect('header')->toBeCalled()->once()->with('Meta-cc-currently-used-config: default');
-				expect('header')->toBeCalled()->once()->with('Meta-cc-final-configured-max-age: 86400');
-				expect('header')->toBeCalled()->once()->with('Cache-Control: max-age=86400, public');
+				expect('header')->toBeCalled()->once()->with('Cache-Control: no-cache, no-store, private');
 
 				$this->sendHeaders->setCacheHeader();
 			});
@@ -236,10 +231,10 @@ describe(\CacheControl\SendHeaders::class, function () {
 			it('is on the local environment', function () {
 				allow('wp_get_environment_type')->toBeCalled()->andReturn('local');
 				expect('get_post_types')->toBeCalled()->once();
-				expect('get_field')->toBeCalled()->times(3);
+				expect('get_field')->toBeCalled()->times(1);
 
 				allow('header')->toBeCalled();
-				expect('header')->toBeCalled()->times(17);
+				expect('header')->toBeCalled()->times(12);
 
 				$this->sendHeaders->setCacheHeader();
 			});
@@ -247,17 +242,16 @@ describe(\CacheControl\SendHeaders::class, function () {
 			it('is on the development environment', function () {
 				allow('wp_get_environment_type')->toBeCalled()->andReturn('development');
 				expect('get_post_types')->toBeCalled()->once();
-				expect('get_field')->toBeCalled()->times(3);
+				expect('get_field')->toBeCalled()->times(1);
 
 				allow('header')->toBeCalled();
-				expect('header')->toBeCalled()->times(17);
+				expect('header')->toBeCalled()->times(12);
 
 				$this->sendHeaders->setCacheHeader();
 			});
 
 			it('is on the staging environment', function () {
 				allow('wp_get_environment_type')->toBeCalled()->andReturn('staging');
-
 				allow('header')->toBeCalled();
 				expect('header')->toBeCalled()->once()->with('Cache-Control: no-cache, no-store, private');
 
@@ -286,10 +280,10 @@ describe(\CacheControl\SendHeaders::class, function () {
 				allow('get_page_template_slug')->toBeCalled()->andReturn('custom-template.php');
 
 				expect('get_post_types')->toBeCalled()->once();
-				expect('get_field')->toBeCalled()->times(3);
+				expect('get_field')->toBeCalled()->times(1);
 
 				allow('header')->toBeCalled();
-				expect('header')->toBeCalled()->times(27);
+				expect('header')->toBeCalled()->times(12);
 
 				$this->sendHeaders->setCacheHeader();
 			});

--- a/src/Options.php
+++ b/src/Options.php
@@ -56,7 +56,7 @@ class Options implements \Dxw\Iguana\Registerable
 		if (function_exists('acf_add_local_field_group')):
 
 			$developer_mode = [];
-			if (wp_get_environment_type() != 'production') {
+			if (wp_get_environment_type() === 'local' || wp_get_environment_type() === 'development') {
 				$developer_mode = [
 					'key' => 'field_cache_control_plugin_settings-developer_mode',
 					'label' => 'Developer mode',

--- a/src/Options.php
+++ b/src/Options.php
@@ -11,6 +11,14 @@ class Options implements \Dxw\Iguana\Registerable
 	{
 		add_action('acf/init', [$this, 'addOptionsPage']);
 		add_action('init', [$this, 'addOptions'], 999);
+		add_filter('plugin_action_links_dxw-cache-control/index.php', [$this, 'addActionLinks']);
+	}
+
+	public function addActionLinks(array $links): array
+	{
+		$settingsLink = '<a href="' . admin_url('options-general.php?page=cache-control-settings') . '">Settings</a>';
+		array_push($links, $settingsLink);
+		return $links;
 	}
 
 	public function addOptionsPage(): void

--- a/src/SendHeaders.php
+++ b/src/SendHeaders.php
@@ -40,7 +40,7 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 		if (count($this->pageProperties)) {
 			// if we are logged in, or on the front page we don't need to worry about configuring things further
 			if (
-				($this->pageProperties['isLoggedInUser'] || $this->pageProperties['requiresPassword'])
+				($this->pageProperties['isLoggedInUser'] || $this->pageProperties['requiresPassword'] || $this->pageProperties['isPreviewPage'])
 				&& !$this->developerMode
 			) {
 				header('Cache-Control: no-cache, no-store, private');
@@ -124,6 +124,7 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 			'isFrontPage' => is_front_page(),
 			'isHomePage' => is_home(),
 			'isLoggedInUser' => is_user_logged_in(),
+			'isPreviewPage' => is_preview(),
 			'postType' => get_post_type() ?? 'unknown',
 			'taxonomies' => get_post_taxonomies() ?? ['none'],
 			'templateName' => get_page_template_slug() ?: 'default',

--- a/src/SendHeaders.php
+++ b/src/SendHeaders.php
@@ -30,7 +30,7 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 
 	public function setCacheHeader(): void
 	{
-		if (wp_get_environment_type() != 'production') {
+		if (wp_get_environment_type() === 'local' || wp_get_environment_type() === 'development') {
 			$this->developerMode = get_field('cache_control_plugin_developer_mode', 'option') ?? false;
 		}
 

--- a/src/SendHeaders.php
+++ b/src/SendHeaders.php
@@ -39,10 +39,7 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 
 		if (count($this->pageProperties)) {
 			// if we are logged in, or on the front page we don't need to worry about configuring things further
-			if (
-				($this->pageProperties['isLoggedInUser'] || $this->pageProperties['requiresPassword'] || $this->pageProperties['isPreviewPage'])
-				&& !$this->developerMode
-			) {
+			if ($this->pageProperties['isLoggedInUser'] || $this->pageProperties['requiresPassword'] || $this->pageProperties['isPreviewPage']) {
 				header('Cache-Control: no-cache, no-store, private');
 				return;
 			}
@@ -51,6 +48,7 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 			 * If something is setting no-cache using the wp_headers filter
 			 * we don't want to mess with that
 			 */
+			/** @psalm-suppress RedundantCondition */
 			if (
 				!$this->pageProperties['isLoggedInUser']
 				&& array_key_exists('Cache-Control', $this->headers)
@@ -75,9 +73,11 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 				$this->getPageConfiguration();
 			}
 
+			/** @psalm-suppress TypeDoesNotContainType */
 			if ($this->pageProperties['isLoggedInUser']) {
 				header('Meta-cc-configured-cache: no-cache (logged in user)');
 			}
+			/** @psalm-suppress TypeDoesNotContainType */
 			if ($this->pageProperties['requiresPassword']) {
 				header('Meta-cc-configured-cache: no-cache (requires password)');
 			}


### PR DESCRIPTION
* FIX company name
* Add link to settings page from the plugins list in the admin dashboard
* Ensure that preview pages are sent with private cache headers
* Make "Developer mode" available only on explicitly local environments

See: 

- https://developer.wordpress.org/reference/functions/is_preview/
- https://developer.wordpress.org/reference/functions/wp_get_environment_type/

## Testing

For the first two commits:

* Install the plugin locally and activate it
* Check that the plugin is on this feature branch
* Stay on the plugins page: http://localhost/wp-admin/plugins.php
* Check that the company name is lowercased
* Check that you see `Deactivate | Settings` underneath the plugin name
* Check that the settings link takes you to: http://localhost/wp-admin/options-general.php?page=cache-control-settings

To reproduce the bug we saw on the staging site:

* Set your environment type in `config/server-local.php` to `define( "WP_ENVIRONMENT_TYPE", "staging" );`
* Install the plugin
* Make sure that the plugin has the `main` branch checked out
* Activate it
* Go to the settings page: http://localhost/wp-admin/options-general.php?page=cache-control-settings
* Change the cache settings so that at least one post type is setting public cache headers in the front end, check this with developer tools in your browser, or `curl` on the command line
* Edit a page of that type
* Preview the page
* Open developer tools on the Network tab and refresh
* Check that you see a cache header that looks something like `max-age=86400, public`

Checkout this feature branch and check that in your local container the code from the feature branch is running (maybe check the settings link appears in the plugins list?).

Run through the steps above again, you should see a cache header that says:

```plaintext
Cache-Control: no-cache, no-store, private
```