### PR TITLE
Refactor/extract page properties

### DIFF
--- a/spec/page.spec.php
+++ b/spec/page.spec.php
@@ -1,0 +1,146 @@
+<?php
+
+describe(\CacheControl\Page::class, function () {
+	beforeEach(function () {
+		$this->page = new \CacheControl\Page();
+	});
+
+	describe('isAdmin()', function () {
+		it('returns the result of is_admin()', function () {
+			allow('is_admin')->toBeCalled()->andReturn(true, false);
+			expect($this->page->isAdmin())->toEqual(true);
+			expect($this->page->isAdmin())->toEqual(false);
+		});
+	});
+
+	describe('isArchivePage()', function () {
+		it('returns the result of is_post_type_archive()', function () {
+			allow('is_post_type_archive')->toBeCalled()->andReturn(true, false);
+			expect($this->page->isArchivePage())->toEqual(true);
+			expect($this->page->isArchivePage())->toEqual(false);
+		});
+	});
+
+	describe('isFrontPage()', function () {
+		it('returns the result of is_front_page()', function () {
+			allow('is_front_page')->toBeCalled()->andReturn(true, false);
+			expect($this->page->isFrontPage())->toEqual(true);
+			expect($this->page->isFrontPage())->toEqual(false);
+		});
+	});
+
+	describe('isHomePage()', function () {
+		it('returns the result of is_home()', function () {
+			allow('is_home')->toBeCalled()->andReturn(true, false);
+			expect($this->page->isHomePage())->toEqual(true);
+			expect($this->page->isHomePage())->toEqual(false);
+		});
+	});
+
+	describe('isLoggedInUser()', function () {
+		it('returns the result of is_user_logged_in()', function () {
+			allow('is_user_logged_in')->toBeCalled()->andReturn(true, false);
+			expect($this->page->isLoggedInUser())->toEqual(true);
+			expect($this->page->isLoggedInUser())->toEqual(false);
+		});
+	});
+
+	describe('isPreviewPage()', function () {
+		it('returns the result of is_preview()', function () {
+			allow('is_preview')->toBeCalled()->andReturn(true, false);
+			expect($this->page->isPreviewPage())->toEqual(true);
+			expect($this->page->isPreviewPage())->toEqual(false);
+		});
+	});
+
+	describe('postType()', function () {
+		context('post type is found', function () {
+			it('returns the result of get_post_type()', function () {
+				allow('get_post_type')->toBeCalled()->andReturn('foo');
+				expect($this->page->postType())->toEqual('foo');
+			});
+		});
+		context('post type is not known', function () {
+			it('returns \'unknown\'', function () {
+				allow('get_post_type')->toBeCalled()->andReturn(null);
+				expect($this->page->postType())->toEqual('unknown');
+			});
+		});
+	});
+
+	describe('taxonomies()', function () {
+		context('post has taxonomies', function () {
+			it('returns the result of get_post_taxonomies()', function () {
+				allow('get_post_taxonomies')->toBeCalled()->andReturn(['foo', 'bar']);
+				expect($this->page->taxonomies())->toEqual(['foo', 'bar']);
+			});
+		});
+		context('post has no taxonomies', function () {
+			it('returns [\'none\']', function () {
+				allow('get_post_taxonomies')->toBeCalled()->andReturn(null);
+				expect($this->page->taxonomies())->toEqual(['none']);
+			});
+		});
+	});
+
+	describe('templateName()', function () {
+		context('get_page_template_slug returns false', function () {
+			it('returns \'default\'', function () {
+				allow('get_page_template_slug')->toBeCalled()->andReturn(false);
+				expect($this->page->templateName())->toEqual('default');
+			});
+		});
+		context('get_page_template_slug returns an empty string', function () {
+			it('returns \'default\'', function () {
+				allow('get_page_template_slug')->toBeCalled()->andReturn('');
+				expect($this->page->templateName())->toEqual('default');
+			});
+		});
+		context('get_page_template_slug returns a popu;lated string', function () {
+			it('returns that string', function () {
+				allow('get_page_template_slug')->toBeCalled()->andReturn('foo');
+				expect($this->page->templateName())->toEqual('foo');
+			});
+		});
+	});
+
+	describe('->requiresPassword()', function () {
+		context('the post has not password set', function () {
+			it('returns false', function () {
+				global $post;
+				$post = (object) [
+					'post_password' => ''
+				];
+				expect($this->page->requiresPassword())->toEqual(false);
+			});
+		});
+		context('the post has a password set', function () {
+			it('returns true', function () {
+				global $post;
+				$post = (object) [
+					'post_password' => 'foobar'
+				];
+				expect($this->page->requiresPassword())->toEqual(true);
+			});
+		});
+	});
+
+	describe('->postId()', function () {
+		context('it returns something that is not an instance of WP_Post', function () {
+			it('returns 0', function () {
+				allow('get_post')->toBeCalled()->andReturn('foo');
+				expect($this->page->postId())->toEqual(0);
+			});
+		});
+		context('it returns a WP_Post object', function () {
+			it('returns the ID of that post', function () {
+				$post = (object) [
+					'ID' => 123
+				];
+				allow('get_post')->toBeCalled()->andReturn($post);
+				allow('is_a')->toBeCalled()->andReturn(true);
+				expect($this->page->postId())->toEqual(123);
+			});
+		});
+	});
+});

--- a/spec/page.spec.php
+++ b/spec/page.spec.php
@@ -62,7 +62,7 @@ describe(\CacheControl\Page::class, function () {
 		});
 		context('post type is not known', function () {
 			it('returns \'unknown\'', function () {
-				allow('get_post_type')->toBeCalled()->andReturn(null);
+				allow('get_post_type')->toBeCalled()->andReturn(false);
 				expect($this->page->postType())->toEqual('unknown');
 			});
 		});

--- a/spec/page.spec.php
+++ b/spec/page.spec.php
@@ -77,7 +77,7 @@ describe(\CacheControl\Page::class, function () {
 		});
 		context('post has no taxonomies', function () {
 			it('returns [\'none\']', function () {
-				allow('get_post_taxonomies')->toBeCalled()->andReturn(null);
+				allow('get_post_taxonomies')->toBeCalled()->andReturn([]);
 				expect($this->page->taxonomies())->toEqual(['none']);
 			});
 		});

--- a/spec/send_headers.spec.php
+++ b/spec/send_headers.spec.php
@@ -4,7 +4,10 @@ use Kahlan\Plugin\Double;
 
 describe(\CacheControl\SendHeaders::class, function () {
 	beforeEach(function () {
-		$this->sendHeaders = new \CacheControl\SendHeaders();
+		$this->page = \Kahlan\Plugin\Double::instance([
+			'extends' => \CacheControl\Page::class
+		]);
+		$this->sendHeaders = new \CacheControl\SendHeaders($this->page);
 
 		global $post;
 		$post = (object) [];
@@ -821,7 +824,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 				});
 
 				it('is a password protected page', function () {
-					allow($this->sendHeaders)->toReceive('hasPassword')->andReturn(true);
+					allow($this->page)->toReceive('requiresPassword')->andReturn(true);
 
 					allow('header')->toBeCalled();
 					expect('header')->toBeCalled()->once()->with('Cache-Control: no-cache, no-store, private');

--- a/spec/send_headers.spec.php
+++ b/spec/send_headers.spec.php
@@ -6,6 +6,8 @@ describe(\CacheControl\SendHeaders::class, function () {
 	beforeEach(function () {
 		$this->sendHeaders = new \CacheControl\SendHeaders();
 
+		global $post;
+		$post = (object) [];
 		allow('is_admin')->toBeCalled()->andReturn(false);
 		allow('is_post_type_archive')->toBeCalled()->andReturn(false);
 		allow('is_front_page')->toBeCalled()->andReturn(false);

--- a/spec/send_headers.spec.php
+++ b/spec/send_headers.spec.php
@@ -11,18 +11,18 @@ describe(\CacheControl\SendHeaders::class, function () {
 
 		global $post;
 		$post = (object) [];
-		allow('is_admin')->toBeCalled()->andReturn(false);
-		allow('is_post_type_archive')->toBeCalled()->andReturn(false);
-		allow('is_front_page')->toBeCalled()->andReturn(false);
-		allow('is_home')->toBeCalled()->andReturn(false);
-		allow('is_user_logged_in')->toBeCalled()->andReturn(false);
-		allow('is_preview')->toBeCalled()->andReturn(false);
-		allow('get_post_type')->toBeCalled()->andReturn('post');
-		allow('get_post_taxonomies')->toBeCalled()->andReturn(['category', 'post_tag', 'custom-taxonomy']);
-		allow('get_page_template_slug')->toBeCalled()->andReturn('default');
+		allow($this->page)->toReceive('isAdmin')->andReturn(false);
+		allow($this->page)->toReceive('isArchivePage')->andReturn(false);
+		allow($this->page)->toReceive('isFrontPage')->andReturn(false);
+		allow($this->page)->toReceive('isHomePage')->andReturn(false);
+		allow($this->page)->toReceive('isLoggedInUser')->andReturn(false);
+		allow($this->page)->toReceive('isPreviewPage')->andReturn(false);
+		allow($this->page)->toReceive('postType')->andReturn('post');
+		allow($this->page)->toReceive('taxonomies')->andReturn(['category', 'post_tag', 'custom-taxonomy']);
+		allow($this->page)->toReceive('templateName')->andReturn('default');
+		allow($this->page)->toReceive('postId')->andReturn(0);
 		allow('get_post_types')->toBeCalled()->andReturn(['post', 'page', 'custom-post']);
 		allow('wp_get_environment_type')->toBeCalled()->andReturn('local');
-		allow('get_post')->toBeCalled()->andReturn(null);
 
 		$this->config = [
 			'cache_control_plugin_developer_mode' => false,
@@ -151,11 +151,11 @@ describe(\CacheControl\SendHeaders::class, function () {
 	describe('->setCacheHeader()', function () {
 		context('we have a logged in user', function () {
 			beforeEach(function () {
-				allow('is_user_logged_in')->toBeCalled()->andReturn(true);
+				allow($this->page)->toReceive('isLoggedInUser')->andReturn(true);
 			});
 
 			it('sets a private cache header for preview pages', function () {
-				allow('is_preview')->toBeCalled()->andReturn(true);
+				allow($this->page)->toReceive('isPreviewPage')->andReturn(true);
 				expect('get_field')->toBeCalled()->once();
 
 				allow('header')->toBeCalled();
@@ -196,7 +196,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 
 		context('the user is not logged in', function () {
 			it('sets a private cache header for preview pages', function () {
-				allow('is_preview')->toBeCalled()->andReturn(true);
+				allow($this->page)->toReceive('isPreviewPage')->andReturn(true);
 				expect('get_field')->toBeCalled()->once();
 
 				allow('header')->toBeCalled();
@@ -208,9 +208,9 @@ describe(\CacheControl\SendHeaders::class, function () {
 
 		context('Testing developer-mode', function () {
 			beforeEach(function () {
-				allow('is_user_logged_in')->toBeCalled()->andReturn(true);
+				allow($this->page)->toReceive('isLoggedInUser')->andReturn(true);
 				$this->config['cache_control_plugin_developer_mode'] = true;
-				allow('is_front_page')->toBeCalled()->andReturn(true);
+				allow($this->page)->toReceive('isFrontPage')->andReturn(true);
 			});
 
 			it('is in developer mode on the local dev environment', function () {
@@ -278,11 +278,11 @@ describe(\CacheControl\SendHeaders::class, function () {
 				$this->config['cache_control_plugin_archives_cache'] = 120;
 				$this->config['cache_control_plugin_home_page_cache'] = 3600;
 
-				allow('is_home')->toBeCalled()->andReturn(true);
-				allow('is_post_type_archive')->toBeCalled()->andReturn(true);
+				allow($this->page)->toReceive('isHomePage')->andReturn(true);
+				allow($this->page)->toReceive('isArchivePage')->andReturn(true);
 				$this->config['cache_control_plugin_developer_mode'] = true;
-				allow('is_front_page')->toBeCalled()->andReturn(false);
-				allow('get_page_template_slug')->toBeCalled()->andReturn('custom-template.php');
+				allow($this->page)->toReceive('isFrontPage')->andReturn(false);
+				allow($this->page)->toReceive('templateName')->andReturn('custom-template.php');
 
 				expect('get_post_types')->toBeCalled()->once();
 				expect('get_field')->toBeCalled()->times(1);
@@ -297,7 +297,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 		context("We don't have a logged in user and the wp_headers filter has values", function () {
 			beforeEach(function () {
 				// for simplicities sake we are using the front page for this example.
-				allow('is_front_page')->toBeCalled()->andReturn(true);
+				allow($this->page)->toReceive('isFrontPage')->andReturn(true);
 			});
 			it('sets a cache-control header with no-cache', function () {
 				// we expect nothing to happen in this instance.
@@ -321,7 +321,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 
 		context('serving the front_page', function () {
 			beforeEach(function () {
-				allow('is_front_page')->toBeCalled()->andReturn(true);
+				allow($this->page)->toReceive('isFrontPage')->andReturn(true);
 			});
 
 			context('has a config value of default', function () {
@@ -377,7 +377,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 
 				it('is in developer mode', function () {
 					$this->config['cache_control_plugin_developer_mode'] = true;
-					allow('is_front_page')->toBeCalled()->andReturn(true);
+					allow($this->page)->toReceive('IsFrontPage')->andReturn(true);
 
 					expect('get_post_types')->toBeCalled()->once();
 					expect('get_field')->toBeCalled()->times(3);
@@ -441,8 +441,8 @@ describe(\CacheControl\SendHeaders::class, function () {
 
 		context('serving the home_page', function () {
 			beforeEach(function () {
-				allow('is_home')->toBeCalled()->andReturn(true);
-				allow('is_post_type_archive')->toBeCalled()->andReturn(true);
+				allow($this->page)->toReceive('isHomePage')->andReturn(true);
+				allow($this->page)->toReceive('isArchivePage')->andReturn(true);
 			});
 
 			it('There is no non-default configuration', function () {
@@ -486,7 +486,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 				});
 
 				it('is configured is also the front page which has default config', function () {
-					allow('is_front_page')->toBeCalled()->andReturn(true);
+					allow($this->page)->toReceive('isFrontPage')->andReturn(true);
 					expect('get_field')->toBeCalled()->times(3);
 
 					allow('header')->toBeCalled();
@@ -496,7 +496,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 				});
 
 				it('is configured is also the front page which has config of 1hr', function () {
-					allow('is_front_page')->toBeCalled()->andReturn(true);
+					allow($this->page)->toReceive('isFrontPage')->andReturn(true);
 					$this->config['cache_control_plugin_front_page_cache'] = '3600';
 					expect('get_field')->toBeCalled()->times(3);
 
@@ -509,7 +509,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 
 			context('home page is not configured', function () {
 				beforeEach(function () {
-					allow('get_post_type')->toBeCalled()->andReturn('post');
+					allow($this->page)->toReceive('postType')->andReturn('post');
 				});
 
 				it('archive is configured', function () {
@@ -563,7 +563,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 
 		context('archive page tests', function () {
 			beforeEach(function () {
-				allow('is_post_type_archive')->toBeCalled()->andReturn(true);
+				allow($this->page)->toReceive('isArchivePage')->andReturn(true);
 			});
 
 			it('There is no non-default configuration', function () {
@@ -707,11 +707,6 @@ describe(\CacheControl\SendHeaders::class, function () {
 
 		context('individual post tests', function () {
 			beforeEach(function () {
-				$this->postObj = Double::instance([
-					'class' => 'WP_Post',
-				]);
-				$this->postObj->ID = 2;
-
 				$this->config['field_cache_control_individual_post_settings'] = [
 					[
 						'cache_control_individual_post_post_id' => 2,
@@ -721,7 +716,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 			});
 
 			it('current page has no post ID', function () {
-				allow('get_post')->toBeCalled()->andReturn(null);
+				allow($this->page)->toReceive('postId')->andReturn(0);
 				allow('header')->toBeCalled();
 				expect('header')->toBeCalled()->once()->with('Cache-Control: max-age=86400, public');
 
@@ -729,7 +724,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 			});
 
 			it('current page has post ID, and a cache override is configured', function () {
-				allow('get_post')->toBeCalled()->andReturn($this->postObj);
+				allow($this->page)->toReceive('postId')->andReturn(2);
 				allow('header')->toBeCalled();
 				expect('header')->toBeCalled()->once()->with('Cache-Control: max-age=120, public');
 
@@ -743,7 +738,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 						'cache_control_individual_post_cache_age' => 'default'
 					]
 				];
-				allow('get_post')->toBeCalled()->andReturn($this->postObj);
+				allow($this->page)->toReceive('postId')->andReturn(2);
 				allow('header')->toBeCalled();
 				expect('header')->toBeCalled()->once()->with('Cache-Control: max-age=86400, public');
 
@@ -757,7 +752,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 						'cache_control_individual_post_cache_age' => 120
 					]
 				];
-				allow('get_post')->toBeCalled()->andReturn($this->postObj);
+				allow($this->page)->toReceive('postId')->andReturn(2);
 				allow('header')->toBeCalled();
 				expect('header')->toBeCalled()->once()->with('Cache-Control: max-age=86400, public');
 
@@ -765,9 +760,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 			});
 
 			it('current page has post ID, but not one configured with a cache override', function () {
-				$this->postObj->ID = 3;
-
-				allow('get_post')->toBeCalled()->andReturn($this->postObj);
+				allow($this->page)->toReceive('postId')->andReturn(3);
 				allow('header')->toBeCalled();
 				expect('header')->toBeCalled()->once()->with('Cache-Control: max-age=86400, public');
 
@@ -810,7 +803,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 
 			context('post_type is page', function () {
 				beforeEach(function () {
-					allow('get_post_type')->toBeCalled()->andReturn('page');
+					allow($this->page)->toReceive('postType')->andReturn('page');
 				});
 
 				it('has the overridden by taxonomy flag set to false', function () {
@@ -923,7 +916,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 			});
 
 			it('categories list has an unexpected taxonomy value', function () {
-				allow('get_post_taxonomies')->toBeCalled()->andReturn(['category', 'post_tag', 'custom-taxonomy', 'nonsense']);
+				allow($this->page)->toReceive('taxonomies')->andReturn(['category', 'post_tag', 'custom-taxonomy', 'nonsense']);
 
 				expect('get_field')->toBeCalled()->times(1);
 				expect('get_sub_field')->toBeCalled()->times(11);
@@ -941,8 +934,8 @@ describe(\CacheControl\SendHeaders::class, function () {
 				$this->config['cache_control_taxonomy_category_settings']['cache_control_taxonomy_category_cache_age'] = 1800;
 				$this->config['cache_control_template_page-custom_settings']['cache_control_template_page-custom_cache_age'] = 604800;
 
-				allow('get_post_type')->toBeCalled()->andReturn('page');
-				allow('get_page_template_slug')->toBeCalled()->andReturn('page-custom.php');
+				allow($this->page)->toReceive('postType')->andReturn('page');
+				allow($this->page)->toReceive('templateName')->andReturn('page-custom.php');
 			});
 
 			it('has a custom template and overridden by template set to false', function () {

--- a/src/Page.php
+++ b/src/Page.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace CacheControl;
+
+class Page
+{
+	public function isAdmin(): bool
+	{
+		return is_admin();
+	}
+
+	public function isArchivePage(): bool
+	{
+		return is_post_type_archive();
+	}
+
+	public function isFrontPage(): bool
+	{
+		return is_front_page();
+	}
+
+	public function isHomePage(): bool
+	{
+		return is_home();
+	}
+
+	public function isLoggedInUser(): bool
+	{
+		return is_user_logged_in();
+	}
+
+	public function isPreviewPage(): bool
+	{
+		return is_preview();
+	}
+
+	public function postType(): string
+	{
+		// Note: this implementation is actually buggy
+		// get_post_type will never return null, only false
+		// Spotted in a refactor, will be fixed in a separate commit
+		return get_post_type() ?? 'unknown';
+	}
+
+	public function taxonomies(): array
+	{
+		// Note: this implementation is actually buggy
+		// get_post_taxonomies will never return null, only an empty array
+		// Spotted in a refactor, will be fixed in a separate commit
+		return get_post_taxonomies() ?? ['none'];
+	}
+
+	public function templateName(): string
+	{
+		return get_page_template_slug() ?: 'default';
+	}
+
+	public function requiresPassword(): bool
+	{
+		global $post;
+		return !empty($post->post_password);
+	}
+
+	public function postId(): int
+	{
+		$post = get_post();
+
+		if (is_a($post, \WP_Post::class)) {
+			return $post->ID;
+		}
+		return 0;
+	}
+}

--- a/src/Page.php
+++ b/src/Page.php
@@ -36,10 +36,7 @@ class Page
 
 	public function postType(): string
 	{
-		// Note: this implementation is actually buggy
-		// get_post_type will never return null, only false
-		// Spotted in a refactor, will be fixed in a separate commit
-		return get_post_type() ?? 'unknown';
+		return get_post_type() ?: 'unknown';
 	}
 
 	public function taxonomies(): array

--- a/src/Page.php
+++ b/src/Page.php
@@ -41,10 +41,7 @@ class Page
 
 	public function taxonomies(): array
 	{
-		// Note: this implementation is actually buggy
-		// get_post_taxonomies will never return null, only an empty array
-		// Spotted in a refactor, will be fixed in a separate commit
-		return get_post_taxonomies() ?? ['none'];
+		return get_post_taxonomies() ?: ['none'];
 	}
 
 	public function templateName(): string

--- a/src/SendHeaders.php
+++ b/src/SendHeaders.php
@@ -9,11 +9,16 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 	protected bool $developerMode = false;
 	protected bool $overriddenByTaxonomy = false;
 	protected string $currentConfig = 'default';
-	protected array $pageProperties = [];
+	protected object $page;
 	protected string $homePageCacheAge = 'default';
 	protected string $frontPageCacheAge = 'default';
 	protected string $archiveCacheAge = 'default';
 	protected array $headers = [];
+
+	public function __construct(\CacheControl\Page $page)
+	{
+		$this->page = $page;
+	}
 
 	public function register(): void
 	{
@@ -37,76 +42,55 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 		//Get our page properties that we will be using to figure out our cache settings,
 		$this->getPageProperties();
 
-		if (count($this->pageProperties)) {
-			// if we are logged in, or on the front page we don't need to worry about configuring things further
-			if ($this->pageProperties['isLoggedInUser'] || $this->pageProperties['requiresPassword'] || $this->pageProperties['isPreviewPage']) {
-				header('Cache-Control: no-cache, no-store, private');
-				return;
-			}
+		// if we are logged in, or on the front page we don't need to worry about configuring things further
+		if ($this->page->isLoggedInUser() || $this->page->requiresPassword() || $this->page->isPreviewPage()) {
+			header('Cache-Control: no-cache, no-store, private');
+			return;
+		}
 
-			/*
-			 * If something is setting no-cache using the wp_headers filter
-			 * we don't want to mess with that
-			 */
-			/** @psalm-suppress RedundantCondition */
-			if (
-				!$this->pageProperties['isLoggedInUser']
-				&& array_key_exists('Cache-Control', $this->headers)
-				&& preg_match('/no-cache/', $this->headers['Cache-Control'])
-			) {
-				return;
-			}
+		/*
+			* If something is setting no-cache using the wp_headers filter
+			* we don't want to mess with that
+			*/
+		/** @psalm-suppress RedundantCondition */
+		if (
+			!$this->page->isLoggedInUser()
+			&& array_key_exists('Cache-Control', $this->headers)
+			&& preg_match('/no-cache/', $this->headers['Cache-Control'])
+		) {
+			return;
+		}
 
-			if ($this->pageProperties['isFrontPage']) {
-				if (is_string(get_field('cache_control_plugin_front_page_cache', 'option'))) {
-					$this->frontPageCacheAge = get_field('cache_control_plugin_front_page_cache', 'option');
-				}
-				if ($this->frontPageCacheAge && $this->frontPageCacheAge != 'default') {
-					$this->currentConfig = 'frontPage';
-					$this->maxAge = (int) $this->frontPageCacheAge;
-				}
-				if ($this->developerMode) {
-					header('Meta-cc-front-page-cache-value: ' . $this->frontPageCacheAge);
-					header('Meta-cc-configured-max-age: ' . $this->maxAge);
-				}
-			} else {
-				$this->getPageConfiguration();
+		if ($this->page->isFrontPage()) {
+			if (is_string(get_field('cache_control_plugin_front_page_cache', 'option'))) {
+				$this->frontPageCacheAge = get_field('cache_control_plugin_front_page_cache', 'option');
 			}
-
-			/** @psalm-suppress TypeDoesNotContainType */
-			if ($this->pageProperties['isLoggedInUser']) {
-				header('Meta-cc-configured-cache: no-cache (logged in user)');
-			}
-			/** @psalm-suppress TypeDoesNotContainType */
-			if ($this->pageProperties['requiresPassword']) {
-				header('Meta-cc-configured-cache: no-cache (requires password)');
+			if ($this->frontPageCacheAge && $this->frontPageCacheAge != 'default') {
+				$this->currentConfig = 'frontPage';
+				$this->maxAge = (int) $this->frontPageCacheAge;
 			}
 			if ($this->developerMode) {
-				header('Meta-cc-currently-used-config: ' . $this->currentConfig);
-				header('Meta-cc-final-configured-max-age: ' . $this->maxAge);
+				header('Meta-cc-front-page-cache-value: ' . $this->frontPageCacheAge);
+				header('Meta-cc-configured-max-age: ' . $this->maxAge);
 			}
+		} else {
+			$this->getPageConfiguration();
 		}
+
+		/** @psalm-suppress TypeDoesNotContainType */
+		if ($this->page->isLoggedInUser()) {
+			header('Meta-cc-configured-cache: no-cache (logged in user)');
+		}
+		/** @psalm-suppress TypeDoesNotContainType */
+		if ($this->page->requiresPassword()) {
+			header('Meta-cc-configured-cache: no-cache (requires password)');
+		}
+		if ($this->developerMode) {
+			header('Meta-cc-currently-used-config: ' . $this->currentConfig);
+			header('Meta-cc-final-configured-max-age: ' . $this->maxAge);
+		}
+
 		header('Cache-Control: max-age=' . $this->maxAge .', public');
-	}
-
-	protected function hasPassword(): bool
-	{
-		global $post;
-
-		return !empty($post->post_password);
-	}
-
-	/**
-	 * @psalm-suppress ArgumentTypeCoercion
-	 */
-	protected function getPostId(): int
-	{
-		$post = get_post();
-
-		if (is_a($post, 'WP_Post')) {
-			return $post->ID;
-		}
-		return 0;
 	}
 
 	/**
@@ -118,33 +102,19 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 	 */
 	protected function getPageProperties(): void
 	{
-		$this->pageProperties = [
-			'isAdmin' => is_admin(),
-			'isArchivePage' => is_post_type_archive(),
-			'isFrontPage' => is_front_page(),
-			'isHomePage' => is_home(),
-			'isLoggedInUser' => is_user_logged_in(),
-			'isPreviewPage' => is_preview(),
-			'postType' => get_post_type() ?? 'unknown',
-			'taxonomies' => get_post_taxonomies() ?? ['none'],
-			'templateName' => get_page_template_slug() ?: 'default',
-			'requiresPassword' => $this->hasPassword(),
-			'postId' => $this->getPostId()
-		];
-
 		// If we are in developer mode we want to see what the current page is setting.
 		if ($this->developerMode) {
-			header('Meta-cc-post-type: ' . $this->pageProperties['postType']);
-			header('Meta-cc-taxonomy:' . implode(',', $this->pageProperties['taxonomies']));
-			header('Meta-cc-front-page: ' . ($this->pageProperties['isFrontPage'] ? 'yes' : 'no'));
-			header('Meta-cc-home-page: ' . ($this->pageProperties['isHomePage'] ? 'yes' : 'no'));
-			header('Meta-cc-archive: ' . ($this->pageProperties['isArchivePage'] ? 'yes' : 'no'));
-			header('Meta-cc-is-admin: ' . ($this->pageProperties['isAdmin'] ? 'yes' : 'no'));
-			header('Meta-cc-logged-in-user: ' . ($this->pageProperties['isLoggedInUser'] ? 'yes' : 'no'));
-			header('Meta-cc-template_name: ' . $this->pageProperties['templateName']);
-			header('Meta-cc-requires-password: ' . ($this->pageProperties['requiresPassword'] ? 'yes' : 'no'));
+			header('Meta-cc-post-type: ' . $this->page->postType());
+			header('Meta-cc-taxonomy:' . implode(',', $this->page->taxonomies()));
+			header('Meta-cc-front-page: ' . ($this->page->isFrontPage() ? 'yes' : 'no'));
+			header('Meta-cc-home-page: ' . ($this->page->isHomePage() ? 'yes' : 'no'));
+			header('Meta-cc-archive: ' . ($this->page->isArchivePage() ? 'yes' : 'no'));
+			header('Meta-cc-is-admin: ' . ($this->page->isAdmin() ? 'yes' : 'no'));
+			header('Meta-cc-logged-in-user: ' . ($this->page->isLoggedInUser() ? 'yes' : 'no'));
+			header('Meta-cc-template_name: ' . $this->page->templateName());
+			header('Meta-cc-requires-password: ' . ($this->page->requiresPassword() ? 'yes' : 'no'));
 			header('Meta-cc-post-types: ' . implode(',', get_post_types(['public' => true])));
-			header('Meta-cc-post-id: '. $this->pageProperties['postId']);
+			header('Meta-cc-post-id: '. $this->page->postId());
 		}
 	}
 
@@ -173,7 +143,7 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 		if (have_rows('field_cache_control_individual_post_settings', 'options')) {
 			$rows = get_field('field_cache_control_individual_post_settings', 'options');
 			foreach ($rows as $row) {
-				if (!empty($row['cache_control_individual_post_post_id']) && $this->pageProperties['postId'] == $row['cache_control_individual_post_post_id']) {
+				if (!empty($row['cache_control_individual_post_post_id']) && $this->page->postId() == $row['cache_control_individual_post_post_id']) {
 					if ($row['cache_control_individual_post_cache_age'] != 'default') {
 						$this->maxAge = $row['cache_control_individual_post_cache_age'];
 					}
@@ -192,18 +162,18 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 		}
 
 		// Get post type options.
-		if (have_rows('cache_control_post_type_' . $this->pageProperties['postType'] . '_settings', 'option')) {
-			while (have_rows('cache_control_post_type_' . $this->pageProperties['postType'] . '_settings', 'option')) {
+		if (have_rows('cache_control_post_type_' . $this->page->postType() . '_settings', 'option')) {
+			while (have_rows('cache_control_post_type_' . $this->page->postType() . '_settings', 'option')) {
 				the_row();
-				$postTypeConfig['maxAge'] = get_sub_field('cache_control_post_type_' . $this->pageProperties['postType'] . '_cache_age');
-				if ($this->pageProperties['postType'] != 'page') {
-					$postTypeConfig['overridesArchive'] = get_sub_field('cache_control_post_type_' . $this->pageProperties['postType'] . '_override_archive');
+				$postTypeConfig['maxAge'] = get_sub_field('cache_control_post_type_' . $this->page->postType() . '_cache_age');
+				if ($this->page->postType() != 'page') {
+					$postTypeConfig['overridesArchive'] = get_sub_field('cache_control_post_type_' . $this->page->postType() . '_override_archive');
 				}
 				$postTypeConfig['overriddenByTaxonomy'] = get_sub_field(
-					'cache_control_post_type_' . $this->pageProperties['postType'] . '_overridden_by_taxonomy'
+					'cache_control_post_type_' . $this->page->postType() . '_overridden_by_taxonomy'
 				) ?: false;
 				$postTypeConfig['overriddenByTemplate'] = get_sub_field(
-					'cache_control_post_type_' . $this->pageProperties['postType'] . '_overridden_by_template'
+					'cache_control_post_type_' . $this->page->postType() . '_overridden_by_template'
 				) ?: false;
 
 				// Only set these values if the maxAge is set to a value other than default.
@@ -223,8 +193,8 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 		}
 
 		// Get taxonomy options.
-		if (count($this->pageProperties['taxonomies']) > 0 && !in_array('none', $this->pageProperties['taxonomies'])) {
-			foreach ($this->pageProperties['taxonomies'] as $taxonomy) {
+		if (count($this->page->taxonomies()) > 0 && !in_array('none', $this->page->taxonomies())) {
+			foreach ($this->page->taxonomies() as $taxonomy) {
 				if (have_rows('cache_control_taxonomy_' . $taxonomy . '_settings', 'option')) {
 					while (have_rows('cache_control_taxonomy_' . $taxonomy . '_settings', 'option')) {
 						the_row();
@@ -250,8 +220,8 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 		}
 
 		// Get template options.
-		if ($this->pageProperties['templateName'] != 'default') {
-			$localTemplateFile = preg_replace('/\.php$/', '', $this->pageProperties['templateName']);
+		if ($this->page->templateName() != 'default') {
+			$localTemplateFile = preg_replace('/\.php$/', '', $this->page->templateName());
 			if ($this->developerMode) {
 				header('Meta-cc-config-template-local-name: ' . $localTemplateFile);
 			}
@@ -279,7 +249,7 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 			header('Meta-cc-config-taxonomy-priority: ' . ($templateConfig['overridesTaxonomy'] ? 'yes' : 'no'));
 		}
 
-		if ($this->pageProperties['isArchivePage']) {
+		if ($this->page->isArchivePage()) {
 			// Do we have a configured taxonomy cache age?
 			if ($taxonomyConfig['maxAge'] != 'default') {
 				$this->currentConfig = 'taxonomy';
@@ -301,7 +271,7 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 			}
 		}
 
-		if ($this->pageProperties['isHomePage']) {
+		if ($this->page->isHomePage()) {
 			if (is_string(get_field('cache_control_plugin_home_page_cache', 'option'))) {
 				$this->homePageCacheAge = get_field('cache_control_plugin_home_page_cache', 'option');
 			}

--- a/src/SendHeaders.php
+++ b/src/SendHeaders.php
@@ -39,8 +39,7 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 			$this->developerMode = get_field('cache_control_plugin_developer_mode', 'option') ?? false;
 		}
 
-		//Get our page properties that we will be using to figure out our cache settings,
-		$this->getPageProperties();
+		$this->outputDeveloperMeta();
 
 		// if we are logged in, or on the front page we don't need to worry about configuring things further
 		if ($this->page->isLoggedInUser() || $this->page->requiresPassword() || $this->page->isPreviewPage()) {
@@ -94,13 +93,14 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 	}
 
 	/**
-	 * getPageProperties
+	 * outputDeveloperMeta
 	 *
-	 * Populate our page properties for the page we are on, set $this->pageValues.
+	 * Output additional info headers
+	 * If in developer mode
 	 *
 	 * @return void
 	 */
-	protected function getPageProperties(): void
+	protected function outputDeveloperMeta(): void
 	{
 		// If we are in developer mode we want to see what the current page is setting.
 		if ($this->developerMode) {

--- a/src/di.php
+++ b/src/di.php
@@ -1,4 +1,7 @@
 <?php
 
-$registrar->addInstance(new \CacheControl\SendHeaders());
+$registrar->addInstance(new \CacheControl\Page());
+$registrar->addInstance(new \CacheControl\SendHeaders(
+	$registrar->getInstance(\CacheControl\Page::class)
+));
 $registrar->addInstance(new \CacheControl\Options());


### PR DESCRIPTION
This PR refactors the `SendHeaders` class to extract the page data out to a separate `Page` model that holds all the information about what kind of page is currently being viewed. This is hopefully the first step in a large refactor to make the plugin's code more modular and developer-friendly.

Essentially, the refactor takes all the logic that was previously put into the `SendHeaders::pageProperties` property and moves it to the `Page` class. This is demonstrated in commit `f42b7b9`, which implements the new class, but does not amend the tests to mock the calls to the new class's methods. Instead, the existing test mocks are retained (which mock the logic that now happens within `Page`'s methods). The fact that the tests all continued to pass demonstrates that no changes to the overall behaviour have occurred. The tests were then refactored fully in the following commit, so that the tests are only examining the single `SendHeaders` class under test.

I have fixed a couple of minor bugs that emerged during the refactor, where we were expecting the wrong kind of return type if `get_post_type()` or `get_post_taxonomies()` fail, but these are edge cases that should not affect standard behaviour of the plugin.

## How to test

1. Run `composer install && vendor/bin/php-cs-fixer fix --dry-run & vendor/bin/psalm && vendor/bin/kahlan spec` to run the tests
2. Install and activate this branch of the plugin on a test site and do some general testing, particularly to ensure that `no-cache` headers are always served if you're e.g. logged in, or viewing a preview