### PR TITLE
Refactor/extract developer mode

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+composer install

--- a/script/test
+++ b/script/test
@@ -1,0 +1,5 @@
+#!/bin/sh
+script/update
+vendor/bin/php-cs-fixer fix --dry-run -vvv
+vendor/bin/psalm
+vendor/bin/kahlan spec

--- a/script/update
+++ b/script/update
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+script/bootstrap

--- a/spec/developer_mode.spec.php
+++ b/spec/developer_mode.spec.php
@@ -1,0 +1,41 @@
+<?php
+
+describe(\CacheControl\DeveloperMode::class, function () {
+	beforeEach(function () {
+		$this->developerMode = new \CacheControl\DeveloperMode();
+	});
+	describe('->addHeader()', function () {
+		it('allows string values to be added', function () {
+			$closure = function () {
+				$this->developerMode->addHeader('foo', 'bar');
+			};
+			expect($closure)->not->toThrow(new \TypeError());
+		});
+		it('allows integer values to be added', function () {
+			$closure = function () {
+				$this->developerMode->addHeader('foo', 123);
+			};
+			expect($closure)->not->toThrow(new \TypeError());
+		});
+		it('does not allow a non-integer or string type value to be added', function () {
+			$closure = function () {
+				$this->developerMode->addHeader('foo', new stdClass());
+			};
+			expect($closure)->toThrow(new \TypeError());
+		});
+	});
+	describe('->output()', function () {
+		it('outputs no headers when none have been added', function () {
+			expect('header')->not->toBeCalled();
+			$this->developerMode->output();
+		});
+		it('outputs headers when they have been added', function () {
+			allow('header')->toBeCalled();
+			$this->developerMode->addHeader('foo', 'bar');
+			$this->developerMode->addHeader('moo', 123);
+			expect('header')->toBeCalled()->once()->with(CacheControl\DeveloperMode::PREFIX . "foo: bar");
+			expect('header')->toBeCalled()->once()->with(CacheControl\DeveloperMode::PREFIX . "moo: 123");
+			$this->developerMode->output();
+		});
+	});
+});

--- a/spec/developer_mode.spec.php
+++ b/spec/developer_mode.spec.php
@@ -60,17 +60,15 @@ describe(\CacheControl\DeveloperMode::class, function () {
 		context('environment type is local', function () {
 			it('returns the option value', function () {
 				allow('wp_get_environment_type')->toBeCalled()->andReturn('local');
-				allow('get_field')->toBeCalled()->andReturn(true, false);
+				allow('get_field')->toBeCalled()->andReturn(true);
 				expect($this->developerMode->active())->toEqual(true);
-				expect($this->developerMode->active())->toEqual(false);
 			});
 		});
 		context('environment type is development', function () {
 			it('returns the option value', function () {
 				allow('wp_get_environment_type')->toBeCalled()->andReturn('development');
-				allow('get_field')->toBeCalled()->andReturn(true, false);
+				allow('get_field')->toBeCalled()->andReturn(true);
 				expect($this->developerMode->active())->toEqual(true);
-				expect($this->developerMode->active())->toEqual(false);
 			});
 		});
 		context('environment type is anything else', function () {
@@ -79,6 +77,14 @@ describe(\CacheControl\DeveloperMode::class, function () {
 				expect('get_field')->not->toBeCalled();
 				expect($this->developerMode->active())->toEqual(false);
 			});
+		});
+		it('memo-ises the value so only needs to call logic once', function () {
+			allow('wp_get_environment_type')->toBeCalled()->andReturn('local');
+			expect('wp_get_environment_type')->toBeCalled()->once();
+			allow('get_field')->toBeCalled()->andReturn(true);
+			expect('get_field')->toBeCalled()->once();
+			expect($this->developerMode->active())->toEqual(true);
+			expect($this->developerMode->active())->toEqual(true);
 		});
 	});
 });

--- a/spec/send_headers.spec.php
+++ b/spec/send_headers.spec.php
@@ -7,7 +7,10 @@ describe(\CacheControl\SendHeaders::class, function () {
 		$this->page = \Kahlan\Plugin\Double::instance([
 			'extends' => \CacheControl\Page::class
 		]);
-		$this->sendHeaders = new \CacheControl\SendHeaders($this->page);
+		$this->developerMode = \Kahlan\Plugin\Double::instance([
+			'extends' => \CacheControl\DeveloperMode::class
+		]);
+		$this->sendHeaders = new \CacheControl\SendHeaders($this->page, $this->developerMode);
 
 		global $post;
 		$post = (object) [];
@@ -219,7 +222,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 
 				allow('header')->toBeCalled();
 				expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-post-type: post');
-				expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-taxonomy:category,post_tag,custom-taxonomy');
+				expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-taxonomy: category,post_tag,custom-taxonomy');
 				expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-front-page: yes');
 				expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-home-page: no');
 				expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-archive: no');
@@ -342,7 +345,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 
 					allow('header')->toBeCalled();
 					expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-post-type: post');
-					expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-taxonomy:category,post_tag,custom-taxonomy');
+					expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-taxonomy: category,post_tag,custom-taxonomy');
 					expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-front-page: yes');
 					expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-home-page: no');
 					expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-archive: no');
@@ -384,7 +387,7 @@ describe(\CacheControl\SendHeaders::class, function () {
 
 					allow('header')->toBeCalled();
 					expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-post-type: post');
-					expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-taxonomy:category,post_tag,custom-taxonomy');
+					expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-taxonomy: category,post_tag,custom-taxonomy');
 					expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-front-page: yes');
 					expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-home-page: no');
 					expect('header')->toBeCalled()->once()->with('X-Debug-dxw-Cache-Control-archive: no');

--- a/src/DeveloperMode.php
+++ b/src/DeveloperMode.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CacheControl;
+
+class DeveloperMode
+{
+	public const PREFIX = 'X-Debug-dxw-Cache-Control-';
+	protected array $headers = [];
+
+	public function addHeader(string $key, int|string $value): void
+	{
+		$this->headers[$key] = $value;
+	}
+
+	public function output(): void
+	{
+		foreach ($this->headers as $key => $value) {
+			header(self::PREFIX . $key . ": " . $value);
+		}
+	}
+}

--- a/src/DeveloperMode.php
+++ b/src/DeveloperMode.php
@@ -14,8 +14,19 @@ class DeveloperMode
 
 	public function output(): void
 	{
-		foreach ($this->headers as $key => $value) {
-			header(self::PREFIX . $key . ": " . $value);
+		if ($this->active()) {
+			foreach ($this->headers as $key => $value) {
+				header(self::PREFIX . $key . ": " . $value);
+			}
 		}
+	}
+
+	public function active(): bool
+	{
+		$result = false;
+		if (wp_get_environment_type() === 'local' || wp_get_environment_type() === 'development') {
+			$result = get_field('cache_control_plugin_developer_mode', 'option') ?? false;
+		}
+		return $result;
 	}
 }

--- a/src/DeveloperMode.php
+++ b/src/DeveloperMode.php
@@ -6,6 +6,7 @@ class DeveloperMode
 {
 	public const PREFIX = 'X-Debug-dxw-Cache-Control-';
 	protected array $headers = [];
+	protected null|bool $active = null;
 
 	public function addHeader(string $key, int|string $value): void
 	{
@@ -23,10 +24,14 @@ class DeveloperMode
 
 	public function active(): bool
 	{
+		if (!is_null($this->active)) {
+			return $this->active;
+		}
 		$result = false;
 		if (wp_get_environment_type() === 'local' || wp_get_environment_type() === 'development') {
 			$result = get_field('cache_control_plugin_developer_mode', 'option') ?? false;
 		}
-		return $result;
+		$this->active = $result;
+		return $this->active;
 	}
 }

--- a/src/SendHeaders.php
+++ b/src/SendHeaders.php
@@ -9,7 +9,7 @@ class SendHeaders implements \Dxw\Iguana\Registerable
 	protected bool $developerMode = false;
 	protected bool $overriddenByTaxonomy = false;
 	protected string $currentConfig = 'default';
-	protected object $page;
+	protected Page $page;
 	protected string $homePageCacheAge = 'default';
 	protected string $frontPageCacheAge = 'default';
 	protected string $archiveCacheAge = 'default';

--- a/src/di.php
+++ b/src/di.php
@@ -1,7 +1,9 @@
 <?php
 
+$registrar->addInstance(new \CacheControl\DeveloperMode());
 $registrar->addInstance(new \CacheControl\Page());
 $registrar->addInstance(new \CacheControl\SendHeaders(
-	$registrar->getInstance(\CacheControl\Page::class)
+	$registrar->getInstance(\CacheControl\Page::class),
+	$registrar->getInstance(\CacheControl\DeveloperMode::class)
 ));
 $registrar->addInstance(new \CacheControl\Options());


### PR DESCRIPTION
This PR is intended to take all the underlying logic around developer mode output and extract it to a separate `DeveloperMode` class. That class can then:

- Take responsibility for outputting the headers (we just tell it what headers we want)
- Take responsibility for knowing if we're in developer mode (so we don't have to check each time we pass it header info, we just check when we decide whether or not to output the developer mode headers)

There's still some further work to do here in refactoring the tests so they reflect this change, but I've deliberately kept the changes so far minimal, to demonstrate that there have been no changes to the plugin's overall behaviour.