### PR TITLE
Add scripts to rule them all

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+composer install

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+script/bootstrap

--- a/script/test
+++ b/script/test
@@ -1,0 +1,5 @@
+#!/bin/sh
+script/update
+vendor/bin/php-cs-fixer fix --dry-run -vvv
+vendor/bin/psalm
+vendor/bin/kahlan spec

--- a/script/update
+++ b/script/update
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+script/bootstrap


### PR DESCRIPTION
Adds the script-to-rule-them-all pattern to ease development.

## How to test

1. Ensure you're running PHP 8.2 or above
1. Run `script/setup` to install the dependencies
1. Run `script/test` to run the tests, which should all run green